### PR TITLE
fixed bug related skip functionality and student status will be able to change in network and without network

### DIFF
--- a/v1.0/frontend/SaralApp/src/modules/ScannedDetails/ScannedDetailsComponent.js
+++ b/v1.0/frontend/SaralApp/src/modules/ScannedDetails/ScannedDetailsComponent.js
@@ -431,8 +431,8 @@ const ScannedDetailsComponent = ({
         let regexvalidate = omrValidation()
     
         let duplication = false
-        const duplicate = checkStdRollDuplicate.some((item) => studentId == item)
-
+        const duplicate = checkStdRollDuplicate.some((item) => studentId == item);
+        const hasSkip = structureList.some((item) => studentId == item.RollNo && item.hasOwnProperty("isNotAbleToSave") && item.isNotAbleToSave);
         if (duplicate && !toggleCheckBox) {
             duplication = true
         } else {
@@ -442,7 +442,7 @@ const ScannedDetailsComponent = ({
             showErrorMessage(regexvalidate[1] ? `${regexvalidate[1]}`: defaultValidateError )
         }
         
-        else if (duplication) {
+        else if (duplication && !hasSkip) {
             callCustomModal(Strings.message_text, Strings.Student_ID_Shouldnt_be_duplicated,false);
         }
        

--- a/v1.0/frontend/SaralApp/src/modules/ScannedDetails/ScannedDetailsComponent.js
+++ b/v1.0/frontend/SaralApp/src/modules/ScannedDetails/ScannedDetailsComponent.js
@@ -429,11 +429,20 @@ const ScannedDetailsComponent = ({
     const goNextFrame = () => {  
         let regexvalidate = omrValidation()
     
-        const addedStd = stdAddRollData.some((item) => studentId == item);
+        const addedStd = stdAddRollData.indexOf(studentId);
+        var duplication = false;
+
+        if (addedStd > -1 && !toggleCheckBox) {
+            duplication = true
+        } else {
+            duplication = false
+            
+        }
+
         if (!toggleCheckBox &&  regexvalidate[0]) {
             showErrorMessage(regexvalidate[1] ? `${regexvalidate[1]}`: defaultValidateError )
         }
-        else if (addedStd) {
+        else if (duplication) {
             callCustomModal(Strings.message_text, Strings.Student_ID_Shouldnt_be_duplicated,false);
         }
        
@@ -464,8 +473,10 @@ const ScannedDetailsComponent = ({
                     }
                 });
                 //save validated student
+                if (toggleCheckBox == false) {
+                    setStdAddRollData([...stdAddRollData, studentId])
+                }
                 dispatch(OcrLocalResponseAction(JSON.parse(JSON.stringify(ocrLocalResponse))))
-                setStdAddRollData([...stdAddRollData, toggleCheckBox == false ? studentId : ''  ])
                 setNewArrayValue(structureList[currentIndex + 1].data)
                 setStudentID(structureList[currentIndex + 1].RollNo)
                 setCurrentIndex(currentIndex + 1)
@@ -763,12 +774,14 @@ const ScannedDetailsComponent = ({
             let toggle = structureList[currentIndex - 1].isNotAbleToSave
             const indexStd = stdAddRollData.indexOf(std);
 
-            if (indexStd > -1) {
+            if (indexStd > -1 & !toggle) {
                 stdAddRollData.splice(indexStd, 1);
+            }
+            if (!toggle) {
+                setStdAddRollData(stdAddRollData)
             }
             setCheckStdRollDuplicate(checkStdRollDuplicate)
             setToggleCheckBox(toggle)
-            setStdAddRollData(stdAddRollData)
             setNewArrayValue(structureList[currentIndex - 1].data)
             setStudentID(structureList[currentIndex - 1].RollNo)
             setCurrentIndex(currentIndex - 1)

--- a/v1.0/frontend/SaralApp/src/modules/ScannedDetails/ScannedDetailsComponent.js
+++ b/v1.0/frontend/SaralApp/src/modules/ScannedDetails/ScannedDetailsComponent.js
@@ -72,6 +72,7 @@ const ScannedDetailsComponent = ({
 
     const [nextBtn, setNextBtn] = useState('SUBMIT')
     const [checkStdRollDuplicate, setCheckStdRollDuplicate] = useState([])
+    const [stdAddRollData, setStdAddRollData] = useState([])
     const [toggleCheckBox, setToggleCheckBox] = useState(false)
     const [logmessage, setLogmessage] = useState()
     const [multiPage, setMultiPage] = useState(0)
@@ -145,8 +146,6 @@ const ScannedDetailsComponent = ({
 
         if(studentId == 0 || studentId == '' && isMultipleStudent){
             setToggleCheckBox(true)
-        }else{
-            setToggleCheckBox(false)
         }
         if (absent.length > 0) {
             setStdErr("Student is Absent")
@@ -430,19 +429,11 @@ const ScannedDetailsComponent = ({
     const goNextFrame = () => {  
         let regexvalidate = omrValidation()
     
-        let duplication = false
-        const duplicate = checkStdRollDuplicate.some((item) => studentId == item);
-        const hasSkip = structureList.some((item) => studentId == item.RollNo && item.hasOwnProperty("isNotAbleToSave") && item.isNotAbleToSave);
-        if (duplicate && !toggleCheckBox) {
-            duplication = true
-        } else {
-            duplication = false
-        }
+        const addedStd = stdAddRollData.some((item) => studentId == item);
         if (!toggleCheckBox &&  regexvalidate[0]) {
             showErrorMessage(regexvalidate[1] ? `${regexvalidate[1]}`: defaultValidateError )
         }
-        
-        else if (duplication && !hasSkip) {
+        else if (addedStd) {
             callCustomModal(Strings.message_text, Strings.Student_ID_Shouldnt_be_duplicated,false);
         }
        
@@ -474,7 +465,7 @@ const ScannedDetailsComponent = ({
                 });
                 //save validated student
                 dispatch(OcrLocalResponseAction(JSON.parse(JSON.stringify(ocrLocalResponse))))
-                setCheckStdRollDuplicate([...checkStdRollDuplicate, studentId])
+                setStdAddRollData([...stdAddRollData, toggleCheckBox == false ? studentId : ''  ])
                 setNewArrayValue(structureList[currentIndex + 1].data)
                 setStudentID(structureList[currentIndex + 1].RollNo)
                 setCurrentIndex(currentIndex + 1)
@@ -770,12 +761,14 @@ const ScannedDetailsComponent = ({
         if (currentIndex - 1 >= 0) {
             let std = structureList[currentIndex - 1].RollNo
             let toggle = structureList[currentIndex - 1].isNotAbleToSave
-            const index = checkStdRollDuplicate.indexOf(std);
-            if (index > -1) {
-                checkStdRollDuplicate.splice(index, 1);
+            const indexStd = stdAddRollData.indexOf(std);
+
+            if (indexStd > -1) {
+                stdAddRollData.splice(indexStd, 1);
             }
             setCheckStdRollDuplicate(checkStdRollDuplicate)
             setToggleCheckBox(toggle)
+            setStdAddRollData(stdAddRollData)
             setNewArrayValue(structureList[currentIndex - 1].data)
             setStudentID(structureList[currentIndex - 1].RollNo)
             setCurrentIndex(currentIndex - 1)

--- a/v1.0/frontend/SaralApp/src/modules/StudentsList/StudentsDataComponent.js
+++ b/v1.0/frontend/SaralApp/src/modules/StudentsList/StudentsDataComponent.js
@@ -79,14 +79,14 @@ const StudentsDataComponent = ({
                 setIsPresent(false)
                 checkStdAbsPrst(data, chkPresent, filteredData, false)
             }
-            if (loginData.data.school.hasOwnProperty("offlineMode") && loginData.data.school.offlineMode && !hasNetwork & (isSheetScanned.length == 0 || isStudentScannedInLocal.length == 0)) {
+            if (loginData.data.school.hasOwnProperty("offlineMode") && loginData.data.school.offlineMode && (isSheetScanned.length == 0 || isStudentScannedInLocal.length == 0)) {
                 saveStudentIntoLocalStorage(data.studentId, isStudentPresent, filterStdData, stdData)
             } 
         } else if (data.studentAvailability == false) {
             data.studentAvailability = true
             setIsPresent(true)
             checkStdAbsPrst(data, chkPresent, filteredData, true)
-            if (loginData.data.school.hasOwnProperty("offlineMode") && loginData.data.school.offlineMode && !hasNetwork & (isSheetScanned.length == 0 || isStudentScannedInLocal.length == 0)) {
+            if (loginData.data.school.hasOwnProperty("offlineMode") && loginData.data.school.offlineMode && (isSheetScanned.length == 0 || isStudentScannedInLocal.length == 0)) {
                 saveStudentIntoLocalStorage(data.studentId, false, filterStdData, stdData)
             } 
         }

--- a/v1.0/frontend/SaralApp/src/modules/StudentsList/StudentsList.js
+++ b/v1.0/frontend/SaralApp/src/modules/StudentsList/StudentsList.js
@@ -367,12 +367,7 @@ useEffect(() => {
         if (absentPresentStatus.studentsMarkInfo.length == 0) {
             setPresentAbsentStudent(allStudentData)
             navigation.push('ScanHistory');
-        } else if(hasNetwork) {
-            let dataPayload = absentPresentStatus
-            let apiObj = new SaveScanData(dataPayload, token)
-            setIsLoading(true)
-            saveStudentData(apiObj)
-        } else if (absentPresentStatus.studentsMarkInfo.length > 0 && !hasNetwork) {
+        }else if (absentPresentStatus.studentsMarkInfo.length > 0) {
             await setDataIntoRegularStudentExamApi()
         }
     }


### PR DESCRIPTION

1) when we are skipping a student id then same student id on next page should not show error message "ID Shouldn't be duplicated"
2) when we fill 000000 for student ID and I skip and proceed, the app should not throws out an error prompt saying that duplicate ID cannot be used.

Absent/present:
1) user will be able to mark any student id as absent or present either network is enable or not.
2) change any student status and click on next button then this student data will be save in mark json.
3) when user save all student mars data including availbility will be saved in db
4) if user mark any student as absent then user won't be able to save that student
