### PR TITLE
bug fix invalid login credential error handling with proper messaging

### DIFF
--- a/v1.0/frontend/SaralApp/src/modules/loginScreens/LoginComponent.js
+++ b/v1.0/frontend/SaralApp/src/modules/loginScreens/LoginComponent.js
@@ -161,13 +161,18 @@ class LoginComponent extends Component {
         const deviceUniqId = await DeviceInfo.getUniqueId();
         let hasNetwork = await checkNetworkConnectivity();
         let hasCacheData = await getLoginApi();
+        let isPasswordMismatchFromCache = false;
 
         let cacheFilterData = hasCacheData != null
             ?
             hasCacheData.filter((element) => {
-                let userId = JSON.parse(element.data.config.data)
-                if (userId.schoolId == schoolId) {
-                    return true
+                let userData = JSON.parse(element.data.config.data)
+                if (userData.schoolId == schoolId) {
+                    if(userData.password == password) {
+                        return true
+                    } else {
+                        isPasswordMismatchFromCache = true
+                    }
                 }
             })
             :
@@ -192,11 +197,18 @@ class LoginComponent extends Component {
                 this.props.APITransport(apiObj);
                 
             })
-        } else if (!hasNetwork && schoolId.length > 0) {
-            this.setState({
-                errCommon: Strings.you_dont_have_cache,
-                isLoading: false
-            })
+        } else if (hasCacheData != null && !hasNetwork && schoolId.length > 0) {
+            if(isPasswordMismatchFromCache) {
+                this.setState({
+                    errCommon: Strings.password_doesnot_match,
+                    isLoading: false
+                })
+            } else {
+                this.setState({
+                    errCommon: Strings.you_dont_have_cache,
+                    isLoading: false
+                })
+            }
         }
         else {
             this.setState({

--- a/v1.0/frontend/SaralApp/src/utils/Strings.js
+++ b/v1.0/frontend/SaralApp/src/utils/Strings.js
@@ -57,6 +57,7 @@ export default strings = new LocalizedStrings({
         userId_text: 'User ID',
         password_text: 'Password',
         schoolid_password_doesnot_match: 'School Id or Password does not match',
+        password_doesnot_match: 'Password does not match',
         subject:'Subject',
         school_name: 'School',
         logout_text: 'Logout',


### PR DESCRIPTION
What?
fixes invalid login credential error handling with proper messaging

Below are the major scenarios it fixes:

1. Login with correct username and password, Logout, then try login with valid username but invalid password, user can successfully login.
2. when user try to login with valid username and password in Offline mode when there is no cache stored then error message should be shown saying "please check your internet connection"
3. In OFFLINE mode if user try to login with school id which does not have cache then it should throw an error saying  "You don't have cache".
4. In OFFLINE mode if user try to login with school id which does have cache but with wrong password then it should throw an error saying  "Password does not match".