### PR TITLE
Changes made to tableCornerDetection

### DIFF
--- a/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/SaralSDKOpenCVScannerActivity.java
+++ b/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/SaralSDKOpenCVScannerActivity.java
@@ -441,6 +441,7 @@ public class SaralSDKOpenCVScannerActivity extends ReactActivity implements Came
             JSONObject threshold1 = layoutObject1.getJSONObject("threshold");
             boolean isExpEdgeDetection = threshold1.has("expPageCornerDetection") && threshold1.getBoolean("expPageCornerDetection");     
             boolean isTableCornerDetection = !isExpEdgeDetection; 
+            Log.d(TAG, "isExpEdgeDetection "+isExpEdgeDetection);
             if(isTableCornerDetection)    
             {
                 tableMat                = mTableCornerDetection.processMat(image,layoutMinWidth,layoutMinHeight,detectionRadius); 
@@ -475,10 +476,12 @@ public class SaralSDKOpenCVScannerActivity extends ReactActivity implements Came
             sound.play(MediaActionSound.FOCUS_COMPLETE);
 
             try {
+
                 JSONObject layoutConfigs = new JSONObject(mlayoutConfigs);
                 JSONObject layoutObject = layoutConfigs.getJSONObject("layout");
                 JSONObject threshold = layoutObject.getJSONObject("threshold");
                 Boolean hasExperimentalOmr = threshold.has("experimentalOMRDetection") ? threshold.getBoolean("experimentalOMRDetection")? true :false:false;
+                Log.d(TAG, "isExpOMRDetection ", +hasExperimentalOmr);
                 for (int i = 0; i < rois.length(); i++) {
                     JSONObject roiConfig  = rois.getJSONObject(i);
 

--- a/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/SaralSDKOpenCVScannerActivity.java
+++ b/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/SaralSDKOpenCVScannerActivity.java
@@ -303,8 +303,8 @@ public class SaralSDKOpenCVScannerActivity extends ReactActivity implements Came
 
     public void onCameraViewStarted(int width, int height) {
         mRgba                           = new Mat(height, width, CvType.CV_8UC4);
-        mTableCornerDetection           = new TableCornerCirclesDetection(false);
-        mDetectShaded                   = new DetectShaded(false);
+        mTableCornerDetection           = new TableCornerCirclesDetection(true);
+        mDetectShaded                   = new DetectShaded(true);
         mTotalClassifiedCount           = 0;
         mIsScanningComplete             = false;
         mScanningResultShared           = false;
@@ -434,8 +434,18 @@ public class SaralSDKOpenCVScannerActivity extends ReactActivity implements Came
         double DARKNESS_THRESHOLD   = 80.0;
         mStartTime                  = SystemClock.uptimeMillis();
         loadLayoutConfiguration();
-        Mat tableMat                = mTableCornerDetection.processMat(image,layoutMinWidth,layoutMinHeight,detectionRadius);
-        if(isMultiChoiceOMRLayout)
+        Mat tableMat;
+        // JSONObject layoutConfigs = new JSONObject(mlayoutConfigs);
+        // JSONObject layoutObject = layoutConfigs.getJSONObject("layout");
+        // JSONObject threshold = layoutObject.getJSONObject("threshold");
+        //Boolean hasExperimentalEdge1 = getBoolean("experimentalEdgeDetection"); //added
+        if(hasExperimentalEdge1){
+            tableMat                = mTableCornerDetection.processMatExp(image,layoutMinWidth,layoutMinHeight,detectionRadius);
+        }else{
+            tableMat                = mTableCornerDetection.processMat(image,layoutMinWidth,layoutMinHeight,detectionRadius);
+
+        }
+            if(isMultiChoiceOMRLayout)
         {
             DARKNESS_THRESHOLD = 70.0;
         }
@@ -460,6 +470,8 @@ public class SaralSDKOpenCVScannerActivity extends ReactActivity implements Came
                 JSONObject layoutObject = layoutConfigs.getJSONObject("layout");
                 JSONObject threshold = layoutObject.getJSONObject("threshold");
                 Boolean hasExperimentalOmr = threshold.has("experimentalOMRDetection") ? threshold.getBoolean("experimentalOMRDetection")? true :false:false;
+                //Boolean hasExperimentalEdge = threshold.has("experimentalEdgeDetection") ? threshold.getBoolean("experimentalEdgeDetection")? true :false:false; //added
+
                 for (int i = 0; i < rois.length(); i++) {
                     JSONObject roiConfig  = rois.getJSONObject(i);
 
@@ -668,6 +680,7 @@ public class SaralSDKOpenCVScannerActivity extends ReactActivity implements Came
                         {
                             //Handling Multi Choice OMR Layout predictions
                             String prediction =mPredictedOMRs.get(roiId);
+                            Log.d(TAG, "prediction" +prediction);
                             if(prediction!=null && prediction.equals("1")){
                                 if (cell.has("omrOptions")) {
                                    JSONArray omrOption = cells.getJSONObject(i).getJSONArray("omrOptions");

--- a/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/opencv/TableCornerCircleDetection.java
+++ b/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/opencv/TableCornerCircleDetection.java
@@ -96,7 +96,7 @@ public class TableCornerCirclesDetection {
             }
 
             if (corners.rows() == 4) {
-                Log.d(TAG, "Detected 4 corners. Sorting points...");        //added
+                Log.d(TAG, "Detected 4 corners. Sorting points...");        
                 CVOperations.sortPointListFromLeft(points);
                 List<Point> leftPoints = new ArrayList<Point>();
                 List<Point> rightPoints = new ArrayList<Point>();
@@ -126,8 +126,8 @@ public class TableCornerCirclesDetection {
                 int maxWidth    = maxX-minX;
                 
                 Rect rectCrop = new Rect((int)((int)topLeft.x+(int)bottomLeft.x)/2, (int)topLeft.y-5, maxWidth, maxHeight+10);
-                Log.d(TAG, "Rect Width " + rectCrop.width+" Rect Height "+rectCrop.height);     //changed
-                Log.d(TAG, "ROI Rect: " + rectCrop);        //added
+                Log.d(TAG, "TableCornerCirclesDetection::processMat() Rect Width " + rectCrop.width+" Rect Height "+rectCrop.height);     
+            
                 if(minWidth > 0 && minHeight > 0 && (rectCrop.width < minWidth || rectCrop.height < minHeight))
                 {
                     showFocusAlert(image);
@@ -152,7 +152,7 @@ public class TableCornerCirclesDetection {
 
                     Mat croppedMat  = cropROI(image, topLeft, topRight, bottomLeft, bottomRight);
                     if (DEBUG){
-                        Log.d(TAG, "Detected corners: " + corners.rows());       //added
+                        Log.d(TAG, "Detected corners: " + corners.rows());       
                         CVOperations.saveImage(croppedMat, "table", 3, false);
                     }
                     return croppedMat;
@@ -175,7 +175,7 @@ public class TableCornerCirclesDetection {
     }
 
     private void showFocusAlert(Mat image) {
-        Log.d(TAG, "Showing Focus Alert");              //added
+        //Log.d(TAG, "Showing Focus Alert");              
         String text     = "Please focus the camera by moving up or down";
         Point position  = new Point(image.width()/6, image.height() / 2);
         Scalar color    = new Scalar(255, 0, 0);
@@ -200,7 +200,6 @@ public class TableCornerCirclesDetection {
                 }
             }
         }
-    
         // Return the validity status
         return isValid;
     }
@@ -210,7 +209,7 @@ public class TableCornerCirclesDetection {
             Imgproc.circle(image, topLeft, 10, new Scalar(255.0, 0.0, 0.0), 10);
             Imgproc.circle(image, topRight, 10, new Scalar(0.0, 255.0, 0.0), 10);
             Imgproc.circle(image, bottomLeft, 10, new Scalar(0.0, 0.0, 255.0), 10);
-            Imgproc.circle(image, bottomRight, 10, new Scalar(255.0, 255.0, 0.0), 10);      //changed
+            Imgproc.circle(image, bottomRight, 10, new Scalar(255.0, 255.0, 0.0), 10);      
         }
         Imgproc.line(image, topLeft,    topRight,       new Scalar(0.0, 255.0, 0.0), 5);
         Imgproc.line(image, bottomLeft, bottomRight,    new Scalar(0.0, 255.0, 0.0), 5);

--- a/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/opencv/TableCornerCircleDetection.java
+++ b/v1.0/frontend/SaralApp/android/saralsdk/src/main/java/org/ekstep/saral/saralsdk/opencv/TableCornerCircleDetection.java
@@ -19,11 +19,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TableCornerCirclesDetection {
-    private static final String  TAG        = "SrlSDK::TableDetector";      //change
+    private static final String  TAG        = "SrlSDK::TableDetector";     
     private boolean DEBUG                   = false; 
     private double mROI                     = 0.0;
     private Point mTopLeft, mTopRight, mBottomLeft, mBottomRight;
-    // private int detectionRadius = 10;
+    private List<Point> points = new ArrayList<Point>();
 
     public Point getmTopLeft() {
         return mTopLeft;
@@ -47,44 +47,55 @@ public class TableCornerCirclesDetection {
     }
 
     public TableCornerCirclesDetection(boolean debug){  
-        debug = true;    //change
         DEBUG = debug;
     }
 
     public Mat processMat(Mat image,int minWidth,int minHeight,int detectionRadius) {
-        Log.d(TAG, "Starting processMat");
-        minHeight = 50;
-        minWidth = 50;                      //added
-        Mat gray        = new Mat();
-        Imgproc.cvtColor(image, gray, Imgproc.COLOR_BGR2GRAY);
-        Imgproc.medianBlur(gray, gray, 11);
-        MatOfPoint corners     = new MatOfPoint();      //changed
-        // Mat thresh = new Mat();
-        // Imgproc.threshold(gray, thresh, 150, 255, Imgproc.THRESH_BINARY);
-        Imgproc.goodFeaturesToTrack(gray, corners, 4, 0.8, 30 );        //changed
-        /**
-         * Draw the detected circles.
-         */
-        if (DEBUG) {
-            Log.d(TAG, "Detected corners: " + corners.rows());       //added
-            drawDetectedCircles(image, corners);        //change
-        }
-        
-        if (corners.rows() > 0) {       //changed
-            Point topLeft, topRight;
-            Point bottomLeft, bottomRight;
 
+        Mat gray        = new Mat();
+        Imgproc.Canny(image, gray, 30, 100);
+        Mat hierarchy = new Mat();
+        List<MatOfPoint> contours = new ArrayList<>();
+        Imgproc.findContours(gray, contours, hierarchy, Imgproc.RETR_EXTERNAL, Imgproc.CHAIN_APPROX_SIMPLE);
+
+        double maxArea          = 0;
+        int maxAreaContourIndex = 0;
+        if (contours.size() > 0) {
+            for (int i = 0; i < contours.size(); i++) {
+                double contourArea = Imgproc.contourArea(contours.get(i));
+                if (maxArea < contourArea) {                                
+                    maxArea                 = contourArea;
+                    maxAreaContourIndex     = i;
+                }
+            }       //gets biggest contour
+
+            Rect r = Imgproc.boundingRect(contours.get(maxAreaContourIndex));       //get coordinates
+            Imgproc.rectangle(image, new Point(r.x, r.y), new Point(r.x + r.width, r.y + r.height), new Scalar(255, 0, 0, 255), 2); //draw
+            
+            Point topLeft = new Point(r.x, r.y);
+            Point topRight = new Point(r.x + r.width, r.y);
+            Point bottomLeft = new Point(r.x, r.y + r.height);
+            Point bottomRight = new Point(r.x + r.width, r.y + r.height);
+
+            Point[] cornerPoints = new Point[4];
+            cornerPoints[0] = topLeft;
+            cornerPoints[1] = topRight;
+            cornerPoints[2] = bottomLeft;
+            cornerPoints[3] = bottomRight;
+            MatOfPoint corners = new MatOfPoint();
+            corners.fromArray(cornerPoints);
             List<Point> points = new ArrayList<Point>();
             for (int i = 0; i < corners.rows(); i++) {
                 double[] point = corners.get(i, 0);
                 points.add(new Point(point[0], point[1]));
-            }     //changed
-            if(detectionRadius > 0 && !hasLayoutDetectionCorners(image, corners,detectionRadius))       //changed
+            }                 
+            if(detectionRadius > 0 && !hasLayoutDetectionCorners(image, corners,detectionRadius))
             {
                 showFocusAlert(image);
                 return null;
             }
-            if (points.size() == 4) {
+
+            if (corners.rows() == 4) {
                 Log.d(TAG, "Detected 4 corners. Sorting points...");        //added
                 CVOperations.sortPointListFromLeft(points);
                 List<Point> leftPoints = new ArrayList<Point>();
@@ -113,7 +124,7 @@ public class TableCornerCirclesDetection {
                 int minX        = Math.min((int)topLeft.x, (int)bottomLeft.x);
                 int maxX        = Math.max((int)topRight.x, (int)bottomRight.x);
                 int maxWidth    = maxX-minX;
-
+                
                 Rect rectCrop = new Rect((int)((int)topLeft.x+(int)bottomLeft.x)/2, (int)topLeft.y-5, maxWidth, maxHeight+10);
                 Log.d(TAG, "Rect Width " + rectCrop.width+" Rect Height "+rectCrop.height);     //changed
                 Log.d(TAG, "ROI Rect: " + rectCrop);        //added
@@ -146,8 +157,8 @@ public class TableCornerCirclesDetection {
                     }
                     return croppedMat;
                 }
-            
-            }else{
+            } 
+            else {
                 Log.d(TAG, "Not enough points detected. Showing focus alert.");
                 showFocusAlert(image);
                 return null;
@@ -155,6 +166,7 @@ public class TableCornerCirclesDetection {
         }
         return null;
     }
+
 
     private final Mat cropROI(Mat image, Point topLeft, Point topRight, Point bottomLeft, Point bottomRight) {
         Mat capturedImage       = image.clone();
@@ -175,27 +187,13 @@ public class TableCornerCirclesDetection {
 
     private final boolean hasLayoutDetectionCorners(Mat src, MatOfPoint corners, int detectionRadius) {
         boolean isValid = true;
-         List<Point> points = new ArrayList<Point>();
-            for (int i = 0; i < corners.rows(); i++) {
-                double[] point = corners.get(i, 0);
-                points.add(new Point(point[0], point[1]));
-            }
-        // Check if there are any detected corners
         if (points.size() > 0) {
-            // Iterate through each detected corner
             for (int i = 0; i < points.size(); i++) {
                 Point corner1 = points.get(i);
-    
-                // Check against other corners
                 for (int j = i + 1; j < points.size(); j++) {
                     Point corner2 = points.get(j);
-    
-                    // Calculate the Euclidean distance between two corners
                     double distance = Math.sqrt(Math.pow(corner2.x - corner1.x, 2) + Math.pow(corner2.y - corner1.y, 2));
-    
-                    // Check if the distance between the corners is less than the specified detection radius
                     if (distance < detectionRadius) {
-                        // If the distance is less than detectionRadius, set isValid to false and break out of the loop
                         isValid = false;
                         break;
                     }
@@ -205,25 +203,6 @@ public class TableCornerCirclesDetection {
     
         // Return the validity status
         return isValid;
-    }
-    
-    
-    
-
-    private final void drawDetectedCircles(Mat src, MatOfPoint corners) {
-        if (corners.rows() > 0) {
-            for (int i = 0; i < corners.rows(); i++) {
-                double[] point = corners.get(i, 0);
-                Point corner = new Point(point[0], point[1]);               //CHANGED FULL
-                Imgproc.circle(src, corner, 10, new Scalar(255,0,255), 3);
-               /*  // circle center
-                Imgproc.circle(src, center, 1, new Scalar(0,100,100), 3, 8, 0 );
-                // circle outline
-                int radius = (int) Math.round(c[2]);
-                // Log.d(TAG, "drawDetectedCircles Circle ("+x+") Radius :: " + radius);
-                Imgproc.circle(src, center, radius, new Scalar(255,0,255), 3, 8, 0 ); */
-            }
-        }
     }
 
     private final void drawPOIArea(Mat image, Point topLeft, Point topRight, Point bottomLeft, Point bottomRight) {


### PR DESCRIPTION
Why:

Page-edge detection was added as an option to improve the flexibility of scanning new layouts. This doesn't require previously printed circles on the page for table corner detection and instead uses contours to detect the edge of the page directly.

What:

The image undergoes Canny edge detection to accentuate edges, from which the most prominent edge representing the page is identified. Subsequently, a bounding rectangle is delineated around the page, and the image is cropped accordingly. 

The option to choose between this page-edge detection method and the traditional circle-based approach is integrated for user convenience. The boolean expression expPageCornerDetection (which is present under the threshold in the layout of the roi file) can be made true to use the new method. These modifications are implemented within the SaralSDKOpenCVScannerActivity function.

Changes made to the rois file:

The new ROI for the image detected through the page corner detection is added in the rois file under the type "corner_detection_example_new".
Complete Description:
https://docs.google.com/document/d/1CkzjVs_hXF311F9xS5Z9mZPOfbzP7VAGk6C0yvMfDbI/edit?usp=sharing
